### PR TITLE
fix: duplicate declarations by naming classes more thoroughly

### DIFF
--- a/transforms/ember-object/__testfixtures__/app/routes/default-import.export.input.js
+++ b/transforms/ember-object/__testfixtures__/app/routes/default-import.export.input.js
@@ -1,0 +1,1 @@
+export default Route.extend({});

--- a/transforms/ember-object/__testfixtures__/app/routes/default-import.export.output.js
+++ b/transforms/ember-object/__testfixtures__/app/routes/default-import.export.output.js
@@ -1,0 +1,1 @@
+export default class DefaultImportExportInputRoute extends Route {}

--- a/transforms/ember-object/__testfixtures__/app/user/edit/profile/default-import.export.input.js
+++ b/transforms/ember-object/__testfixtures__/app/user/edit/profile/default-import.export.input.js
@@ -1,0 +1,1 @@
+export default Route.extend({});

--- a/transforms/ember-object/__testfixtures__/app/user/edit/profile/default-import.export.output.js
+++ b/transforms/ember-object/__testfixtures__/app/user/edit/profile/default-import.export.output.js
@@ -1,0 +1,1 @@
+export default class EditProfileDefaultImportExportInputRoute extends Route {}

--- a/transforms/ember-object/__testfixtures__/app/users/default-import.export.input.js
+++ b/transforms/ember-object/__testfixtures__/app/users/default-import.export.input.js
@@ -1,0 +1,1 @@
+export default Route.extend({});

--- a/transforms/ember-object/__testfixtures__/app/users/default-import.export.output.js
+++ b/transforms/ember-object/__testfixtures__/app/users/default-import.export.output.js
@@ -1,0 +1,1 @@
+export default class UsersDefaultImportExportInputRoute extends Route {}

--- a/transforms/ember-object/__testfixtures__/app/users/index/default-import.export.input.js
+++ b/transforms/ember-object/__testfixtures__/app/users/index/default-import.export.input.js
@@ -1,0 +1,1 @@
+export default Route.extend({});

--- a/transforms/ember-object/__testfixtures__/app/users/index/default-import.export.output.js
+++ b/transforms/ember-object/__testfixtures__/app/users/index/default-import.export.output.js
@@ -1,0 +1,1 @@
+export default class UsersIndexDefaultImportExportInputRoute extends Route {}

--- a/transforms/helpers/parse-helper.js
+++ b/transforms/helpers/parse-helper.js
@@ -485,7 +485,6 @@ function getClassName(
     const dirWithoutFile = path.dirname(appFilePath);
     // Only keep no more then the last two directories
     // Ignore any that are plural of the superclass name
-    // debugger;
     const lastTwoDirsOrLess = dirWithoutFile
       .split("/")
       .slice(-2)


### PR DESCRIPTION
Resolves #51 

This doesn't support MU, only mixed layouts.
Ran it against one app and it transformed 305 files with 

```
node ~/ember-es6-class-codemod/bin/cli.js ember-object --decorators=true --quotes=single app/**/*.js
```