### PR TITLE
Avoid `**/tmp/**` when looking for `package.json`'s.

### DIFF
--- a/transforms/helpers/util/get-telemetry-for.js
+++ b/transforms/helpers/util/get-telemetry-for.js
@@ -9,7 +9,7 @@ const APP_PATHS = {};
 
 let packagePaths = walkSync('./', {
   globs: ['**/package.json'],
-  ignore: ['node_modules/**'],
+  ignore: ['**/tmp/**', '**/node_modules/**'],
 });
 
 for (let packagePath of packagePaths) {


### PR DESCRIPTION
Attempt to fix #138.

Part of the issues in #138 is that `tmp/` is being "walked" for `package.json`'s (on accident) so that we can properly map from the runtime module paths to the local on disk paths. Unfortunately, when walking the current directory `tmp` _may_ still be around (especially when using ember-cli that is still using broccoli@0.16.x where the `tmp` is in the project).

This PR adds `tmp` to the list of paths to ignore, which should help us avoid the issue described in https://github.com/joliss/node-walk-sync/pull/44.