### PR TITLE
Remove remaining traces of wrapComputed.

### DIFF
--- a/test/fixtures/output/app/components/test-component.js
+++ b/test/fixtures/output/app/components/test-component.js
@@ -10,6 +10,6 @@ function fullNameMacro() {
 
 @classic
 export default class TestComponentComponent extends Component {
-  @fullNameMacro
+  @fullNameMacro()
   fullName;
 }

--- a/transforms/ember-object/__testfixtures__/-mock-telemetry.json
+++ b/transforms/ember-object/__testfixtures__/-mock-telemetry.json
@@ -1,6 +1,6 @@
 {
   "runtime.input": {
-    "computedProperties": ["computedMacro", "anotherMacro", "numPlusOne", "numPlusPlus"],
+    "computedProperties": ["computedMacro", "anotherMacro", "numPlusOne", "numPlusPlus", "error", "errorService"],
     "observedProperties": [],
     "observerProperties": {},
     "offProperties": { "offProp": ["prop1", "prop2"] },
@@ -9,5 +9,16 @@
     "ownProperties": [],
     "type": "EmberObject",
     "unobservedProperties": { "unobservedProp": ["prop3", "prop4"] }
+  },
+  "injecting-service.input": {
+    "computedProperties": ["something", "otherThing"],
+    "observedProperties": [],
+    "observerProperties": {},
+    "offProperties": {},
+    "overriddenActions": [],
+    "overriddenProperties": [],
+    "ownProperties": [],
+    "type": "Service",
+    "unobservedProperties": {}
   }
 }

--- a/transforms/ember-object/__testfixtures__/-mock-telemetry.json
+++ b/transforms/ember-object/__testfixtures__/-mock-telemetry.json
@@ -1,6 +1,6 @@
 {
   "runtime.input": {
-    "computedProperties": ["computedMacro", "numPlusOne", "numPlusPlus"],
+    "computedProperties": ["computedMacro", "anotherMacro", "numPlusOne", "numPlusPlus"],
     "observedProperties": [],
     "observerProperties": {},
     "offProperties": { "offProp": ["prop1", "prop2"] },

--- a/transforms/ember-object/__testfixtures__/injecting-service.input.js
+++ b/transforms/ember-object/__testfixtures__/injecting-service.input.js
@@ -1,6 +1,6 @@
 import Service, { service as injectService } from '@ember/service';
 
 export default Service.extend({
-  something: service(),
-  otherThing: service('some-thing')
+  something: injectService(),
+  otherThing: injectService('some-thing'),
 });

--- a/transforms/ember-object/__testfixtures__/injecting-service.input.js
+++ b/transforms/ember-object/__testfixtures__/injecting-service.input.js
@@ -1,0 +1,6 @@
+import Service, { service as injectService } from '@ember/service';
+
+export default Service.extend({
+  something: service(),
+  otherThing: service('some-thing')
+});

--- a/transforms/ember-object/__testfixtures__/injecting-service.output.js
+++ b/transforms/ember-object/__testfixtures__/injecting-service.output.js
@@ -3,9 +3,9 @@ import Service, { service as injectService } from '@ember/service';
 
 @classic
 export default class InjectingServiceInputService extends Service {
-  @service
+  @injectService()
   something;
 
-  @service('some-thing')
+  @injectService('some-thing')
   otherThing;
 }

--- a/transforms/ember-object/__testfixtures__/injecting-service.output.js
+++ b/transforms/ember-object/__testfixtures__/injecting-service.output.js
@@ -1,0 +1,11 @@
+import classic from 'ember-classic-decorator';
+import Service, { service as injectService } from '@ember/service';
+
+@classic
+export default class InjectingServiceInputService extends Service {
+  @service
+  something;
+
+  @service('some-thing')
+  otherThing;
+}

--- a/transforms/ember-object/__testfixtures__/runtime.input.js
+++ b/transforms/ember-object/__testfixtures__/runtime.input.js
@@ -16,8 +16,8 @@ export default RuntimeInput.extend(MyMixin, {
   [MY_VAL]: 'val',
   queryParams: {},
 
-  // error: service(),
-  // errorService: service('error'),
+  error: service(),
+  errorService: service('error'),
 
   unobservedProp: null,
   offProp: null,

--- a/transforms/ember-object/__testfixtures__/runtime.input.js
+++ b/transforms/ember-object/__testfixtures__/runtime.input.js
@@ -1,6 +1,7 @@
 import RuntimeInput from 'common/runtime/input';
 import { alias } from '@ember/object/computed';
 import { computed } from '@ember/object';
+import { service } from '@ember/service';
 
 /**
  * Program comments
@@ -15,6 +16,9 @@ export default RuntimeInput.extend(MyMixin, {
   [MY_VAL]: 'val',
   queryParams: {},
 
+  // error: service(),
+  // errorService: service('error'),
+
   unobservedProp: null,
   offProp: null,
 
@@ -25,6 +29,11 @@ export default RuntimeInput.extend(MyMixin, {
   numPlusPlus: alias('numPlusOne'),
 
   computedMacro: customMacro(),
+
+  anotherMacro: customMacroWithInput({
+    foo: 123,
+    bar: 'baz'
+  }),
 
   /**
    * Method comments

--- a/transforms/ember-object/__testfixtures__/runtime.output.js
+++ b/transforms/ember-object/__testfixtures__/runtime.output.js
@@ -2,6 +2,7 @@ import classic from 'ember-classic-decorator';
 import { off, unobserves } from '@ember-decorators/object';
 import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
+import RuntimeInput from 'common/runtime/input';
 import { service } from '@ember/service';
 
 /**

--- a/transforms/ember-object/__testfixtures__/runtime.output.js
+++ b/transforms/ember-object/__testfixtures__/runtime.output.js
@@ -2,7 +2,7 @@ import classic from 'ember-classic-decorator';
 import { off, unobserves } from '@ember-decorators/object';
 import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import RuntimeInput from 'common/runtime/input';
+import { service } from '@ember/service';
 
 /**
  * Program comments
@@ -19,6 +19,10 @@ export default class RuntimeInputEmberObject extends RuntimeInput.extend(MyMixin
   [MY_VAL] = 'val';
   queryParams = {};
 
+  @service error;
+
+  @service('error') errorService;
+
   @unobserves('prop3', 'prop4')
   unobservedProp;
 
@@ -33,8 +37,14 @@ export default class RuntimeInputEmberObject extends RuntimeInput.extend(MyMixin
   @alias('numPlusOne')
   numPlusPlus;
 
-  @customMacro
+  @customMacro()
   computedMacro;
+
+  @customMacroWithInput({
+    foo: 123,
+    bar: 'baz'
+  })
+  anotherMacro;
 
   /**
    * Method comments

--- a/transforms/ember-object/__testfixtures__/runtime.output.js
+++ b/transforms/ember-object/__testfixtures__/runtime.output.js
@@ -19,9 +19,11 @@ export default class RuntimeInputEmberObject extends RuntimeInput.extend(MyMixin
   [MY_VAL] = 'val';
   queryParams = {};
 
-  @service error;
+  @service
+  error;
 
-  @service('error') errorService;
+  @service('error')
+  errorService;
 
   @unobserves('prop3', 'prop4')
   unobservedProp;

--- a/transforms/helpers/EOProp.js
+++ b/transforms/helpers/EOProp.js
@@ -141,10 +141,6 @@ class EOProp {
     return this.decoratorNames.includes('off');
   }
 
-  get hasWrapComputedDecorator() {
-    return this.decoratorNames.includes('wrapComputed');
-  }
-
   get hasRuntimeData() {
     return !!this.runtimeType;
   }
@@ -164,15 +160,18 @@ class EOProp {
   setDecorators(importedDecoratedProps) {
     if (this.isCallExpression) {
       this.setCallExpressionProps();
+
       const { decoratorName, isMethodDecorator, isMetaDecorator, importedName } =
         importedDecoratedProps[this.calleeName] || {};
+
       if (decoratorName) {
         this.hasMapDecorator = importedName === 'map';
         this.hasFilterDecorator = importedName === 'filter';
-        this.hasComputedDecorator = importedName === 'computed';
         this.hasMethodDecorator = isMethodDecorator;
         this.hasMetaDecorator = isMetaDecorator;
         this.decoratorNames.push(decoratorName);
+      } else if (this.isComputed) {
+        this.decoratorNames.push(this.calleeName);
       }
     }
   }
@@ -201,6 +200,7 @@ class EOProp {
     if (!type) {
       return;
     }
+
     const name = this.name;
     if (Object.keys(unobservedProperties).includes(name)) {
       this.decoratorNames.push('unobserves');
@@ -210,8 +210,8 @@ class EOProp {
       this.decoratorNames.push('off');
       this.decoratorArgs['off'] = offProperties[name];
     }
-    if (computedProperties.includes(name) && !this.hasComputedDecorator && !this.hasMetaDecorator) {
-      this.decoratorNames.push('wrapComputed');
+    if (computedProperties.includes(name)) {
+      this.isComputed = true;
     }
     if (this.isAction) {
       this.overriddenActions = overriddenActions;

--- a/transforms/helpers/EOProp.js
+++ b/transforms/helpers/EOProp.js
@@ -89,11 +89,12 @@ class EOProp {
   }
 
   get shouldRemoveLastArg() {
-    const lastArg = this.callExprArgs.slice(-1) || [];
+    const lastArg = this.callExprArgs[this.callExprArgs.length - 1];
 
     return (
-      lastArg.length > 0 &&
-      (lastArg[0].type === 'FunctionExpression' || lastArg[0].type === 'ObjectExpression')
+      lastArg &&
+      (lastArg.type === 'FunctionExpression' ||
+        (this.decoratorNames.includes('computed') && lastArg.type === 'ObjectExpression'))
     );
   }
 

--- a/transforms/helpers/decorator-helper.js
+++ b/transforms/helpers/decorator-helper.js
@@ -46,10 +46,6 @@ function createCallExpressionDecorators(j, decoratorName, instanceProp) {
     return [];
   }
 
-  if (instanceProp.hasWrapComputedDecorator) {
-    return j.decorator(j.identifier(instanceProp.calleeName));
-  }
-
   const decoratorArgs =
     !instanceProp.hasMapDecorator &&
     !instanceProp.hasFilterDecorator &&
@@ -57,19 +53,24 @@ function createCallExpressionDecorators(j, decoratorName, instanceProp) {
       ? instanceProp.callExprArgs.slice(0, -1)
       : instanceProp.callExprArgs.slice(0);
 
-  const decoratorExpr = instanceProp.modifiers.reduce(
+  let decoratorExpression =
+    instanceProp.isComputed && decoratorArgs.length === 0
+      ? j.identifier(decoratorName)
+      : j.callExpression(j.identifier(decoratorName), decoratorArgs);
+
+  decoratorExpression = instanceProp.modifiers.reduce(
     (callExpr, modifier) =>
       j.callExpression(j.memberExpression(callExpr, modifier.prop), modifier.args),
-    j.callExpression(j.identifier(decoratorName), decoratorArgs)
+    decoratorExpression
   );
 
   if (!instanceProp.modifiers.length) {
-    return j.decorator(decoratorExpr);
+    return j.decorator(decoratorExpression);
   }
 
   // If has modifiers wrap decorators in anonymous call expression
   // it transforms @computed('').readOnly() => @(computed('').readOnly())
-  return j.decorator(j.callExpression(j.identifier(''), [decoratorExpr]));
+  return j.decorator(j.callExpression(j.identifier(''), [decoratorExpression]));
 }
 
 /**

--- a/transforms/helpers/decorator-helper.js
+++ b/transforms/helpers/decorator-helper.js
@@ -46,12 +46,9 @@ function createCallExpressionDecorators(j, decoratorName, instanceProp) {
     return [];
   }
 
-  const decoratorArgs =
-    !instanceProp.hasMapDecorator &&
-    !instanceProp.hasFilterDecorator &&
-    instanceProp.shouldRemoveLastArg
-      ? instanceProp.callExprArgs.slice(0, -1)
-      : instanceProp.callExprArgs.slice(0);
+  const decoratorArgs = instanceProp.shouldRemoveLastArg
+    ? instanceProp.callExprArgs.slice(0, -1)
+    : instanceProp.callExprArgs.slice(0);
 
   let decoratorExpression =
     ['computed', 'service', 'controller'].includes(decoratorName) && decoratorArgs.length === 0

--- a/transforms/helpers/decorator-helper.js
+++ b/transforms/helpers/decorator-helper.js
@@ -54,7 +54,7 @@ function createCallExpressionDecorators(j, decoratorName, instanceProp) {
       : instanceProp.callExprArgs.slice(0);
 
   let decoratorExpression =
-    instanceProp.isComputed && decoratorArgs.length === 0
+    ['computed', 'service', 'controller'].includes(decoratorName) && decoratorArgs.length === 0
       ? j.identifier(decoratorName)
       : j.callExpression(j.identifier(decoratorName), decoratorArgs);
 

--- a/transforms/helpers/import-helper.js
+++ b/transforms/helpers/import-helper.js
@@ -21,20 +21,20 @@ function getDecoratorInfo(specifier, importPropDecoratorMap) {
   const importedName = get(specifier, 'imported.name');
   const isImportedAs = importedName !== localName;
   const isMetaDecorator = !importPropDecoratorMap;
-  let decoratorName;
+  let name;
   if (isImportedAs) {
-    decoratorName = localName;
+    name = localName;
   } else {
     if (isMetaDecorator) {
-      decoratorName = localName;
+      name = localName;
     } else {
-      decoratorName = importPropDecoratorMap[importedName];
+      name = importPropDecoratorMap[importedName];
     }
   }
 
   const isMethodDecorator = METHOD_DECORATORS.includes(importedName);
   return {
-    decoratorName,
+    name,
     importedName,
     isImportedAs,
     isMetaDecorator,

--- a/transforms/helpers/parse-helper.js
+++ b/transforms/helpers/parse-helper.js
@@ -35,8 +35,8 @@ function getEmberObjectProps(j, eoExpression, importedDecoratedProps = {}, runti
     } else if (prop.name === 'attributeBindings') {
       Object.assign(attributeBindingsProps, parseBindingProps(prop.value.elements));
     } else {
-      prop.setDecorators(importedDecoratedProps);
       prop.setRuntimeData(runtimeData);
+      prop.setDecorators(importedDecoratedProps);
       instanceProps.push(prop);
     }
   });
@@ -83,7 +83,6 @@ function getDecoratorsToImportMap(instanceProps, decoratorsMap = {}) {
   return instanceProps.reduce((specs, prop) => {
     return {
       action: specs.action || prop.isAction,
-      wrapComputed: specs.wrapComputed || prop.hasWrapComputedDecorator,
       attribute: specs.attribute || prop.hasAttributeDecorator,
       className: specs.className || prop.hasClassNameDecorator,
       classNames: specs.classNames || prop.isClassNames,

--- a/transforms/helpers/transform-helper.js
+++ b/transforms/helpers/transform-helper.js
@@ -304,9 +304,7 @@ function createCallExpressionProp(j, callExprProp) {
   const lastArgType =
     !callExprProp.hasMapDecorator &&
     !callExprProp.hasFilterDecorator &&
-    !callExprProp.hasWrapComputedDecorator
-      ? get(callExprLastArg, 'type')
-      : '';
+    get(callExprLastArg, 'type');
 
   if (lastArgType === 'FunctionExpression') {
     const functionExpr = {

--- a/transforms/helpers/transform-helper.js
+++ b/transforms/helpers/transform-helper.js
@@ -305,10 +305,7 @@ function createCallExpressionProp(j, callExprProp) {
     callExprLastArg = callExprArgs.pop();
   }
 
-  const lastArgType =
-    !callExprProp.hasMapDecorator &&
-    !callExprProp.hasFilterDecorator &&
-    get(callExprLastArg, 'type');
+  const lastArgType = get(callExprLastArg, 'type');
 
   if (callExprProp.shouldRemoveLastArg) {
     if (lastArgType === 'FunctionExpression') {
@@ -398,6 +395,7 @@ function createClass(
       classBody.push(createClassProp(j, prop));
     }
   });
+
   return withDecorators(
     j.classDeclaration(
       className ? j.identifier(className) : null,

--- a/transforms/helpers/transform-helper.js
+++ b/transforms/helpers/transform-helper.js
@@ -306,29 +306,31 @@ function createCallExpressionProp(j, callExprProp) {
     !callExprProp.hasFilterDecorator &&
     get(callExprLastArg, 'type');
 
-  if (lastArgType === 'FunctionExpression') {
-    const functionExpr = {
-      isComputed: true,
-      kind: callExprProp.kind,
-      key: callExprProp.key,
-      value: callExprLastArg,
-      comments: callExprProp.comments,
-    };
-    return [createMethodProp(j, functionExpr, createInstancePropDecorators(j, callExprProp))];
-  } else if (lastArgType === 'ObjectExpression') {
-    const callExprMethods = callExprLastArg.properties.map(callExprFunction => {
-      callExprFunction.isComputed = true;
-      callExprFunction.kind = getPropName(callExprFunction);
-      callExprFunction.key = callExprProp.key;
-      callExprFunction.value.params.shift();
-      return createMethodProp(j, callExprFunction);
-    });
+  if (callExprProp.decoratorNames.includes('computed')) {
+    if (lastArgType === 'FunctionExpression') {
+      const functionExpr = {
+        isComputed: true,
+        kind: callExprProp.kind,
+        key: callExprProp.key,
+        value: callExprLastArg,
+        comments: callExprProp.comments,
+      };
+      return [createMethodProp(j, functionExpr, createInstancePropDecorators(j, callExprProp))];
+    } else if (lastArgType === 'ObjectExpression') {
+      const callExprMethods = callExprLastArg.properties.map(callExprFunction => {
+        callExprFunction.isComputed = true;
+        callExprFunction.kind = getPropName(callExprFunction);
+        callExprFunction.key = callExprProp.key;
+        callExprFunction.value.params.shift();
+        return createMethodProp(j, callExprFunction);
+      });
 
-    withDecorators(
-      withComments(callExprMethods[0], callExprProp),
-      createInstancePropDecorators(j, callExprProp)
-    );
-    return callExprMethods;
+      withDecorators(
+        withComments(callExprMethods[0], callExprProp),
+        createInstancePropDecorators(j, callExprProp)
+      );
+      return callExprMethods;
+    }
   } else {
     return [createClassProp(j, callExprProp)];
   }

--- a/transforms/helpers/transform-helper.js
+++ b/transforms/helpers/transform-helper.js
@@ -300,13 +300,17 @@ function createActionDecoratedProps(j, actionsProp) {
  */
 function createCallExpressionProp(j, callExprProp) {
   const callExprArgs = callExprProp.callExprArgs.slice(0);
-  const callExprLastArg = callExprArgs.pop();
+  let callExprLastArg;
+  if (callExprProp.shouldRemoveLastArg) {
+    callExprLastArg = callExprArgs.pop();
+  }
+
   const lastArgType =
     !callExprProp.hasMapDecorator &&
     !callExprProp.hasFilterDecorator &&
     get(callExprLastArg, 'type');
 
-  if (callExprProp.decoratorNames.includes('computed')) {
+  if (callExprProp.shouldRemoveLastArg) {
     if (lastArgType === 'FunctionExpression') {
       const functionExpr = {
         isComputed: true,


### PR DESCRIPTION
* Moves `setRuntimeData` _before_ `setDecorators` so that we can more easily setup local state in `setDecorators`
* Removes remaining references to `wrapComputed` * Adds `.isComputed` boolean to `EOProp` class to allow us to track when the runtime data indicates that a given property was a computed property.
* Update decorator building code to avoid creating a call expression for decorators that are returning computed properties without arguments (e.g. use `@someComputedMacro` vs `@someComputedMacro()`)

First step in addressing #142 and #144