### PR TITLE
[FEAT] Fixup name logic, make it work with pods

### DIFF
--- a/lib/gather-telemetry.js
+++ b/lib/gather-telemetry.js
@@ -54,6 +54,7 @@ module.exports = async function gatherTelemetry(url) {
         'Service',
         'Router',
         'Engine',
+        'Helper',
       ];
       return types.find(type => Ember[type] && object instanceof Ember[type]) || 'EmberObject';
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "update-docs": "codemod-cli update-docs"
   },
   "dependencies": {
-    "codemod-cli": "^1.0.0",
+    "codemod-cli": "^2.0.0",
     "fs-extra": "^8.0.1",
     "git-repo-info": "^2.1.0",
     "minimatch": "^3.0.4",

--- a/test/fixtures/output/app/app.js
+++ b/test/fixtures/output/app/app.js
@@ -5,12 +5,12 @@ import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 @classic
-class AppApplication extends Application {
+class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
 }
 
-loadInitializers(AppApplication, config.modulePrefix);
+loadInitializers(App, config.modulePrefix);
 
-export default AppApplication;
+export default App;

--- a/test/fixtures/output/app/components/test-component.js
+++ b/test/fixtures/output/app/components/test-component.js
@@ -9,7 +9,7 @@ function fullNameMacro() {
 }
 
 @classic
-export default class TestComponentComponent extends Component {
+export default class TestComponent extends Component {
   @fullNameMacro()
   fullName;
 }

--- a/test/fixtures/output/app/router.js
+++ b/test/fixtures/output/app/router.js
@@ -3,11 +3,11 @@ import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
 @classic
-class RouterRouter extends EmberRouter {
+class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 }
 
-RouterRouter.map(function() {});
+Router.map(function() {});
 
-export default RouterRouter;
+export default Router;

--- a/transforms/ember-object/__testfixtures__/-mock-telemetry.json
+++ b/transforms/ember-object/__testfixtures__/-mock-telemetry.json
@@ -1,5 +1,5 @@
 {
-  "runtime.input": {
+  "runtime": {
     "computedProperties": ["computedMacro", "anotherMacro", "numPlusOne", "numPlusPlus", "error", "errorService"],
     "observedProperties": [],
     "observerProperties": {},
@@ -10,7 +10,7 @@
     "type": "EmberObject",
     "unobservedProperties": { "unobservedProp": ["prop3", "prop4"] }
   },
-  "injecting-service.input": {
+  "injecting-service": {
     "computedProperties": ["something", "otherThing"],
     "observedProperties": [],
     "observerProperties": {},
@@ -20,5 +20,23 @@
     "ownProperties": [],
     "type": "Service",
     "unobservedProperties": {}
+  },
+  "types/components/basic": {
+    "type": "Component"
+  },
+  "types/controllers/basic": {
+    "type": "Controller"
+  },
+  "types/helpers/basic": {
+    "type": "Helper"
+  },
+  "types/routes/basic": {
+    "type": "Route"
+  },
+  "types/services/basic": {
+    "type": "Service"
+  },
+  "types/pods/foo/controller": {
+    "type": "Controller"
   }
 }

--- a/transforms/ember-object/__testfixtures__/decorators.output.js
+++ b/transforms/ember-object/__testfixtures__/decorators.output.js
@@ -90,7 +90,7 @@ class Foo extends EmberObject {
 @classic
 @classNameBindings('isEnabled:enabled:disabled', 'a:b:c', 'c:d')
 @attributeBindings('customHref:href')
-class Comp extends EmberObject {
+class comp extends EmberObject {
   @computed('a', 'c')
   get isEnabled() {
     return false;

--- a/transforms/ember-object/__testfixtures__/default-export.output.js
+++ b/transforms/ember-object/__testfixtures__/default-export.output.js
@@ -1,3 +1,3 @@
 import classic from 'ember-classic-decorator';
 @classic
-export default class DefaultExportInput extends EmberObject {}
+export default class DefaultExport extends EmberObject {}

--- a/transforms/ember-object/__testfixtures__/import.output.js
+++ b/transforms/ember-object/__testfixtures__/import.output.js
@@ -5,17 +5,17 @@ import Controller from '@ember/controller';
 import Evented from '@ember/object/evented';
 
 @classic
-class Ser extends Service {}
+class ser extends Service {}
 
 @classic
-class Ctrl extends Controller {}
+class ctrl extends Controller {}
 
 @classic
-class Evt extends Service.extend(Evented) {
+class evt extends Service.extend(Evented) {
   @on('click')
   e() {
     return 'e';
   }
 }
 
-export { Ser, Ctrl, Evt };
+export { ser, ctrl, evt };

--- a/transforms/ember-object/__testfixtures__/injecting-service.output.js
+++ b/transforms/ember-object/__testfixtures__/injecting-service.output.js
@@ -2,7 +2,7 @@ import classic from 'ember-classic-decorator';
 import Service, { service as injectService } from '@ember/service';
 
 @classic
-export default class InjectingServiceInputService extends Service {
+export default class InjectingServiceService extends Service {
   @injectService()
   something;
 

--- a/transforms/ember-object/__testfixtures__/runtime.input.js
+++ b/transforms/ember-object/__testfixtures__/runtime.input.js
@@ -1,4 +1,4 @@
-import RuntimeInput from 'common/runtime/input';
+import Runtime from 'common/runtime';
 import { alias } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import { service } from '@ember/service';
@@ -6,7 +6,7 @@ import { service } from '@ember/service';
 /**
  * Program comments
  */
-export default RuntimeInput.extend(MyMixin, {
+export default Runtime.extend(MyMixin, {
   /**
    * Property comments
    */

--- a/transforms/ember-object/__testfixtures__/runtime.output.js
+++ b/transforms/ember-object/__testfixtures__/runtime.output.js
@@ -2,14 +2,14 @@ import classic from 'ember-classic-decorator';
 import { off, unobserves } from '@ember-decorators/object';
 import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import RuntimeInput from 'common/runtime/input';
+import Runtime from 'common/runtime';
 import { service } from '@ember/service';
 
 /**
  * Program comments
  */
 @classic
-export default class RuntimeInputEmberObject extends RuntimeInput.extend(MyMixin) {
+export default class _Runtime extends Runtime.extend(MyMixin) {
   /**
    * Property comments
    */

--- a/transforms/ember-object/__testfixtures__/types/components/basic.input.js
+++ b/transforms/ember-object/__testfixtures__/types/components/basic.input.js
@@ -1,0 +1,3 @@
+import Component from '@ember/component';
+
+export default Component.extend({});

--- a/transforms/ember-object/__testfixtures__/types/components/basic.output.js
+++ b/transforms/ember-object/__testfixtures__/types/components/basic.output.js
@@ -2,4 +2,4 @@ import classic from 'ember-classic-decorator';
 import Component from '@ember/component';
 
 @classic
-export default class FireSauce extends Component {}
+export default class Basic extends Component {}

--- a/transforms/ember-object/__testfixtures__/types/controllers/basic.input.js
+++ b/transforms/ember-object/__testfixtures__/types/controllers/basic.input.js
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({});

--- a/transforms/ember-object/__testfixtures__/types/controllers/basic.output.js
+++ b/transforms/ember-object/__testfixtures__/types/controllers/basic.output.js
@@ -1,0 +1,5 @@
+import classic from 'ember-classic-decorator';
+import Controller from '@ember/controller';
+
+@classic
+export default class BasicController extends Controller {}

--- a/transforms/ember-object/__testfixtures__/types/helpers/basic.input.js
+++ b/transforms/ember-object/__testfixtures__/types/helpers/basic.input.js
@@ -1,0 +1,3 @@
+import Helper from '@ember/component/helper';
+
+export default Helper.extend({});

--- a/transforms/ember-object/__testfixtures__/types/helpers/basic.output.js
+++ b/transforms/ember-object/__testfixtures__/types/helpers/basic.output.js
@@ -1,0 +1,5 @@
+import classic from 'ember-classic-decorator';
+import Helper from '@ember/component/helper';
+
+@classic
+export default class Basic extends Helper {}

--- a/transforms/ember-object/__testfixtures__/types/pods/foo/controller.input.js
+++ b/transforms/ember-object/__testfixtures__/types/pods/foo/controller.input.js
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({});

--- a/transforms/ember-object/__testfixtures__/types/pods/foo/controller.output.js
+++ b/transforms/ember-object/__testfixtures__/types/pods/foo/controller.output.js
@@ -1,0 +1,5 @@
+import classic from 'ember-classic-decorator';
+import Controller from '@ember/controller';
+
+@classic
+export default class FooController extends Controller {}

--- a/transforms/ember-object/__testfixtures__/types/routes/basic.input.js
+++ b/transforms/ember-object/__testfixtures__/types/routes/basic.input.js
@@ -1,0 +1,3 @@
+import Route from '@ember/route';
+
+export default Route.extend({});

--- a/transforms/ember-object/__testfixtures__/types/routes/basic.output.js
+++ b/transforms/ember-object/__testfixtures__/types/routes/basic.output.js
@@ -1,0 +1,5 @@
+import classic from 'ember-classic-decorator';
+import Route from '@ember/route';
+
+@classic
+export default class BasicRoute extends Route {}

--- a/transforms/ember-object/__testfixtures__/types/services/basic.input.js
+++ b/transforms/ember-object/__testfixtures__/types/services/basic.input.js
@@ -1,4 +1,6 @@
+import Service from '@ember/service';
+
 /**
  * Program comments
  */
-const Foo = Test.extend({});
+export default Service.extend({});

--- a/transforms/ember-object/__testfixtures__/types/services/basic.output.js
+++ b/transforms/ember-object/__testfixtures__/types/services/basic.output.js
@@ -1,7 +1,8 @@
 import classic from 'ember-classic-decorator';
+import Service from '@ember/service';
 
 /**
  * Program comments
  */
 @classic
-class Foo extends Test {}
+export default class BasicService extends Service {}

--- a/transforms/ember-object/test.js
+++ b/transforms/ember-object/test.js
@@ -16,7 +16,7 @@ let testFiles = walkSync('./transforms/ember-object/__testfixtures__', {
 let mockTelemetry = {};
 
 for (let testFile of testFiles) {
-  let moduleName = testFile.replace(/\.[^/.]+$/, '');
+  let moduleName = testFile.replace(/\.input\.[^/.]+$/, '');
   let value = mockTelemetryData[moduleName] || {};
 
   mockTelemetry[path.resolve(__dirname, `./__testfixtures__/${moduleName}`)] = value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,10 +1718,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemod-cli@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/codemod-cli/-/codemod-cli-1.1.0.tgz#c1e59a9430f8a17a7fc9dc9a91f8c477a1b4dc6f"
-  integrity sha512-sPqwdXeK1lKF+Z+JLrKMiFgxAQlk/+cI/9kFMS6h+ufTpjw5vIBCRujWTfs1pasliT6u3uzkM25uBQTlHrUvuQ==
+codemod-cli@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/codemod-cli/-/codemod-cli-2.0.0.tgz#c8c88b1a6ecba6e357a4c0439856366074826734"
+  integrity sha512-gpFtCbDQ4kzCahqL6eXoxk+u/vH3Nfn0gatiwpsMHBk3zJMqQ1g1N4n6Fz+J9F9VsEEshgtJ0sRrpFh7EQWMTQ==
   dependencies:
     "@babel/parser" "^7.4.5"
     chalk "^2.4.2"


### PR DESCRIPTION
Fixes up the name logic:

* Defaults to the existing variable name if it exists (changing a variable name would be a breaking change)
* Adds a class name with appended type for Controllers/Routes/Services, without for Components/Helpers/Other
* If there's a collision with the super class name, prepends `_` to the new class name
* If the name that is detected is the same as the base type, it means we are in pods (e.g. `controller.js` -> `Controller` === the type of the object), and it now looks up one directory level to get the name of the parent folder.