### PR TITLE
[BUGFIX] Ignore chained class definitions

### DIFF
--- a/transforms/ember-object/__testfixtures__/chained-class-definition.input.js
+++ b/transforms/ember-object/__testfixtures__/chained-class-definition.input.js
@@ -1,0 +1,3 @@
+import EmberObject from '@ember/object';
+
+export default EmberObject.extend({}).reopenClass({});

--- a/transforms/ember-object/__testfixtures__/chained-class-definition.output.js
+++ b/transforms/ember-object/__testfixtures__/chained-class-definition.output.js
@@ -1,0 +1,3 @@
+import EmberObject from '@ember/object';
+
+export default EmberObject.extend({}).reopenClass({});

--- a/transforms/helpers/parse-helper.js
+++ b/transforms/helpers/parse-helper.js
@@ -208,6 +208,11 @@ function replaceEmberObjectExpressions(j, root, filePath, options = {}) {
     );
 
     const errors = hasValidProps(j, eoProps, options);
+
+    if (get(eoCallExpression, 'parentPath.value.type') === 'MemberExpression') {
+      errors.push('class has chained definition (e.g. EmberObject.extend().reopenClass();');
+    }
+
     if (errors.length) {
       logger.warn(`[${filePath}]: FAILURE \nValidation errors: \n\t${errors.join('\n\t')}`);
       return;


### PR DESCRIPTION
Before this change, class definitions that were chained like so:

```js
export default EmberObject.extend({}).reopenClass({});
```

Would become:

```js
export default class Foo {}.reopenClass({});
```

Which is not valid JS. These are a relatively uncommon type of class
definition, so this PR adds them to our ignore list and spits out an
error.