### PR TITLE
Don't append object name when type is already at the end of the filename

### DIFF
--- a/transforms/ember-object/__testfixtures__/-mock-telemetry.json
+++ b/transforms/ember-object/__testfixtures__/-mock-telemetry.json
@@ -41,6 +41,9 @@
   "types/services/basic": {
     "type": "Service"
   },
+  "types/services/some-service": {
+    "type": "Service"
+  },
   "types/pods/foo/controller": {
     "type": "Controller"
   },

--- a/transforms/ember-object/__testfixtures__/injecting-service.output.js
+++ b/transforms/ember-object/__testfixtures__/injecting-service.output.js
@@ -2,7 +2,7 @@ import classic from 'ember-classic-decorator';
 import Service, { service as injectService } from '@ember/service';
 
 @classic
-export default class InjectingServiceService extends Service {
+export default class InjectingService extends Service {
   @injectService()
   something;
 

--- a/transforms/ember-object/__testfixtures__/types/services/some-service.input.js
+++ b/transforms/ember-object/__testfixtures__/types/services/some-service.input.js
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default Service.extend();

--- a/transforms/ember-object/__testfixtures__/types/services/some-service.output.js
+++ b/transforms/ember-object/__testfixtures__/types/services/some-service.output.js
@@ -1,0 +1,5 @@
+import classic from 'ember-classic-decorator';
+import Service from '@ember/service';
+
+@classic
+export default class SomeService extends Service {}

--- a/transforms/helpers/parse-helper.ts
+++ b/transforms/helpers/parse-helper.ts
@@ -104,7 +104,10 @@ export function getClassName(
     );
   }
 
-  if (!['Component', 'Helper', 'EmberObject'].includes(type)) {
+  if (
+    !['Component', 'Helper', 'EmberObject'].includes(type) &&
+    !className.endsWith(type)
+  ) {
     className = `${className}${capitalizedType}`;
   }
 


### PR DESCRIPTION
In cases where the object you are migrating has the object name at the end of its filename, this gets duplicated into the classname which looks weird.

For example, a service called `my-important-service.js` will be transformed to the following JS

```js
export default class MyImportantServiceService extends Service {
```

This change makes sure not to duplicate the object name if the filename already ends in it. This now looks like:

```js
export default class MyImportantService extends Service {
```