### PR TITLE
Passing boolean flag options not working correctly

### DIFF
--- a/transforms/ember-object/index.js
+++ b/transforms/ember-object/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { getOptions } = require('codemod-cli');
+const { getCoercedOptions } = require('../helpers/options');
 const { replaceEmberObjectExpressions } = require('../helpers/parse-helper');
 
 const DEFAULT_OPTIONS = {
@@ -18,7 +18,11 @@ module.exports = function transformer(file, api) {
   }
 
   const j = api.jscodeshift;
-  const options = Object.assign({}, DEFAULT_OPTIONS, getOptions());
+  const options = Object.assign(
+    {},
+    DEFAULT_OPTIONS,
+    getCoercedOptions(['decorators', 'classFields', 'classicDecorator'])
+  );
   let { source } = file;
 
   const root = j(source);

--- a/transforms/helpers/options.js
+++ b/transforms/helpers/options.js
@@ -1,0 +1,13 @@
+const { getOptions } = require('codemod-cli');
+
+module.exports = {
+  getCoercedOptions(keys) {
+    const options = getOptions();
+    Object.keys(options).forEach(key => {
+      if (keys.includes(key)) {
+        options[key] = options.key == 'true';
+      }
+    });
+    return options;
+  },
+};


### PR DESCRIPTION
In the documentation it says you can disable various features by setting a flag to `false`. For example, `--classic-decorator=false` will disable the insertion of the `@classic` decorator.

This doesn't work correctly because passing `--classic-decorator=false` actually gets transformed to `{ classicDecorator: 'false' }`. The `classicDecorator` value is actually a string value of `false` and therefore truthy.

I've implemented a naive coercing of the strings back into booleans. I'm open to any suggestions if you think there is a better way of doing this. Could this be fixed upstream in codemod-cli as that does provide the original `getOptions` function?