### PR TITLE
Passing boolean flag options not working correctly

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 'use strict';
+const argv = require('yargs')
+  .boolean(['class-fields', 'decorators', 'classic-decorator'])
+  .string(['type', 'quote']).argv;
 
 const { gatherTelemetryForUrl, analyzeEmberObject } = require('ember-codemods-telemetry-helpers');
 
 (async () => {
-  await gatherTelemetryForUrl(process.argv[2], analyzeEmberObject);
+  await gatherTelemetryForUrl(argv[2], analyzeEmberObject);
 
   require('codemod-cli').runTransform(
     __dirname,
     'ember-object',
-    process.argv.slice(2) /* paths or globs */
+    argv.slice(2) /* paths or globs */
   );
 })();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,17 +1,50 @@
 #!/usr/bin/env node
 'use strict';
-const argv = require('yargs')
-  .boolean(['class-fields', 'decorators', 'classic-decorator'])
-  .string(['type', 'quote']).argv;
 
 const { gatherTelemetryForUrl, analyzeEmberObject } = require('ember-codemods-telemetry-helpers');
 
-(async () => {
-  await gatherTelemetryForUrl(argv[2], analyzeEmberObject);
+const argv = require('yargs').command(
+  '$0 <url>',
+  'A codemod for transforming your ember app code to native JavaScript class syntax with decorators!',
+  yargs => {
+    yargs
+      .positional('url', {
+        describe: 'the path to the server',
+        type: 'string',
+      })
+      .option('class-fields', {
+        description: 'Enable/disable transformation using class fields',
+        type: 'boolean',
+        default: true,
+      })
+      .option('decorators', {
+        description: 'Enable/disable transformation using decorators',
+        type: 'boolean',
+        default: true,
+      })
+      .option('classic-decorator', {
+        description:
+          'Enable/disable adding the @classic decorator, which helps with transitioning Ember Octane',
+        type: 'boolean',
+        default: true,
+      })
+      .option('type', {
+        description:
+          'Apply transformation to only passed type. The type can be one of services, routes, components, controllers',
+        type: 'string',
+        default: '',
+      })
+      .option('quote', {
+        description:
+          'Whether to use double or single quotes by default for new statements that are added during the codemod.',
+        type: 'string',
+        default: 'single',
+      });
+  }
+).argv;
 
-  require('codemod-cli').runTransform(
-    __dirname,
-    'ember-object',
-    argv.slice(2) /* paths or globs */
-  );
+(async () => {
+  await gatherTelemetryForUrl(argv.url, analyzeEmberObject);
+
+  require('codemod-cli').runTransform(__dirname, 'ember-object', argv._ /* paths or globs */);
 })();

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "puppeteer": "^1.17.0",
     "sync-disk-cache": "^1.3.3",
     "walk-sync": "^2.0.2",
-    "winston": "^3.2.1"
+    "winston": "^3.2.1",
+    "yargs": "^14.2.0"
   },
   "devDependencies": {
     "eslint": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6959,7 +6959,7 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-yargs-parser@15.0.0:
+yargs-parser@15.0.0, yargs-parser@^15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
   integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
@@ -7040,6 +7040,23 @@ yargs@^13.2.0, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.0.tgz#f116a9242c4ed8668790b40759b4906c276e76c3"
+  integrity sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.0"
 
 yauzl@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
In the documentation it says you can disable various features by setting a flag to `false`. For example, `--classic-decorator=false` will disable the insertion of the `@classic` decorator.

This doesn't work correctly because passing `--classic-decorator=false` actually gets transformed to `{ classicDecorator: 'false' }`. The `classicDecorator` value is actually a string value of `false` and therefore truthy.

I originally opened this in the closed PR https://github.com/ember-codemods/ember-native-class-codemod/pull/212 but I revisited the approach.

I've introduced a change where we now use `yargs` parse the options into their correct types, i.e. Boolean and String. This means Booleans are now accurately represented.

I haven't added a test but any suggestions on how to test this are welcome.

/cc @NullVoxPopuli @rwjblue 