### PR TITLE
Support running codemod against an addon's dummy app

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "codemod-cli": "^2.0.0",
-    "ember-codemods-telemetry-helpers": "^2.0.0",
+    "ember-codemods-telemetry-helpers": "^2.1.0",
     "fs-extra": "^8.0.1",
     "git-repo-info": "^2.1.0",
     "minimatch": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,10 +2815,10 @@ electron-to-chromium@^1.3.103:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
   integrity sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==
 
-ember-codemods-telemetry-helpers@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-codemods-telemetry-helpers/-/ember-codemods-telemetry-helpers-2.0.0.tgz#fd5c000dd77eba5e95571d59291c6405d1b66d05"
-  integrity sha512-Q2UeibyB3JHJEg+MFMZ+RIFn78XYGN26Zs9GPIJlW/jIMQS3vvKHEJIKpnflMtwZG8SxcEONY4ahtEi9ESF8jg==
+ember-codemods-telemetry-helpers@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-codemods-telemetry-helpers/-/ember-codemods-telemetry-helpers-2.1.0.tgz#99625bfbaedd990d7a0a2ea964c4f677a921647c"
+  integrity sha512-ZDKQRjPcv7YnzzHn479slHlK57HvVbIAldySGrUao+sl3XRLlTAEeVJNZRZNn+wG/vNwcF11c2GRXW2vPrhiPQ==
   dependencies:
     fs-extra "^8.1.0"
     git-repo-info "^2.1.0"


### PR DESCRIPTION
This includes a bug fix to support addon dummy app files. https://github.com/ember-codemods/ember-codemods-telemetry-helpers/pull/40