### PR TITLE
Fix bug where service imported without inject as would error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 *.log
 .eslintcache
-transforms/**/*.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.organizeImports": true
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit"
   },
   "typescript.preferences.importModuleSpecifierEnding": "index",
   "typescript.suggest.autoImports": true

--- a/package.json
+++ b/package.json
@@ -88,5 +88,9 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
+  },
+  "volta": {
+    "node": "16.20.2",
+    "yarn": "1.22.21"
   }
 }

--- a/transforms/ember-object/__testfixtures__/inject-basic.input.js
+++ b/transforms/ember-object/__testfixtures__/inject-basic.input.js
@@ -1,0 +1,7 @@
+import { inject as controller } from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+const Foo1 = EmberObject.extend({
+  b: service('store'),
+  myController: controller('abc'),
+});

--- a/transforms/ember-object/__testfixtures__/inject-basic.output.js
+++ b/transforms/ember-object/__testfixtures__/inject-basic.output.js
@@ -1,0 +1,12 @@
+import classic from 'ember-classic-decorator';
+import { inject as controller } from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+@classic
+class Foo1 extends EmberObject {
+  @service('store')
+  b;
+
+  @controller('abc')
+  myController;
+}

--- a/transforms/ember-object/__testfixtures__/runtime.output.js
+++ b/transforms/ember-object/__testfixtures__/runtime.output.js
@@ -1,9 +1,9 @@
 import classic from 'ember-classic-decorator';
 import { off, unobserves } from '@ember-decorators/object';
 import { action, computed } from '@ember/object';
+import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Runtime from 'common/runtime';
-import { service } from '@ember/service';
 
 /**
  * Program comments

--- a/transforms/ember-object/__testfixtures__/service-basic.input.js
+++ b/transforms/ember-object/__testfixtures__/service-basic.input.js
@@ -1,0 +1,5 @@
+import { service } from '@ember/service';
+
+const Foo1 = EmberObject.extend({
+  b: service('store'),
+});

--- a/transforms/ember-object/__testfixtures__/service-basic.output.js
+++ b/transforms/ember-object/__testfixtures__/service-basic.output.js
@@ -1,0 +1,8 @@
+import classic from 'ember-classic-decorator';
+import { service } from '@ember/service';
+
+@classic
+class Foo1 extends EmberObject {
+  @service('store')
+  b;
+}

--- a/transforms/helpers/util/index.ts
+++ b/transforms/helpers/util/index.ts
@@ -73,6 +73,7 @@ export const DECORATOR_PATHS: ReadonlyMap<string, DecoratorPathInfo> = new Map([
     {
       importPropDecoratorMap: {
         inject: 'inject',
+        service: 'service',
       },
       decoratorPath: '@ember/service',
     },


### PR DESCRIPTION
- Fix dev env
- Fix bug where `service` imported without `inject as` would error (`Transform not supported - call to 'service' cannot be transformed`) in some cases with missing telemetry
